### PR TITLE
5-add-a-create-method-for-both-oauthclients-to-create-default-clients

### DIFF
--- a/src/main/java/com/indeed/authorization/client/ThreeLeggedOAuthClient.java
+++ b/src/main/java/com/indeed/authorization/client/ThreeLeggedOAuthClient.java
@@ -42,6 +42,13 @@ import static com.indeed.authorization.client.common.IndeedPrompt.PROMPT_KEY;
 public class ThreeLeggedOAuthClient extends OAuthClient {
 
     public static ThreeLeggedOAuthClient create3LeggedOAuth2Client(
+            final String clientId, final String clientSecret)
+            throws GeneralException, IOException {
+        return new ThreeLeggedOAuthClient(
+                clientId, clientSecret, DEFAULT_ISSUER_URL, DEFAULT_CONNECTION_TIMEOUT);
+    }
+
+    public static ThreeLeggedOAuthClient create3LeggedOAuth2Client(
             final String clientId, final String clientSecret, final String hostname)
             throws GeneralException, IOException {
         return new ThreeLeggedOAuthClient(

--- a/src/main/java/com/indeed/authorization/client/TwoLeggedOAuthClient.java
+++ b/src/main/java/com/indeed/authorization/client/TwoLeggedOAuthClient.java
@@ -30,6 +30,13 @@ import java.util.Objects;
 public class TwoLeggedOAuthClient extends OAuthClient {
 
     public static TwoLeggedOAuthClient create2LeggedOAuth2Client(
+            final String clientId, final String clientSecret)
+            throws GeneralException, IOException {
+        return new TwoLeggedOAuthClient(
+                clientId, clientSecret, DEFAULT_ISSUER_URL, DEFAULT_CONNECTION_TIMEOUT);
+    }
+
+    public static TwoLeggedOAuthClient create2LeggedOAuth2Client(
             final String clientId, final String clientSecret, final String hostname)
             throws GeneralException, IOException {
         return new TwoLeggedOAuthClient(


### PR DESCRIPTION
what is new?

Added new methods to create default oauth clients for both 2-legged and 3-legged.

```
 public static ThreeLeggedOAuthClient create3LeggedOAuth2Client(
            final String clientId, final String clientSecret)
            throws GeneralException, IOException {
        return new ThreeLeggedOAuthClient(
                clientId, clientSecret, DEFAULT_ISSUER_URL, DEFAULT_CONNECTION_TIMEOUT);
    }
```

```
 public static TwoLeggedOAuthClient create2LeggedOAuth2Client(
            final String clientId, final String clientSecret)
            throws GeneralException, IOException {
        return new TwoLeggedOAuthClient(
                clientId, clientSecret, DEFAULT_ISSUER_URL, DEFAULT_CONNECTION_TIMEOUT);
    }
```